### PR TITLE
Fjernet sårbare biblioteker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <cxf.version>3.5.10</cxf.version>
+        <cxf-codegen.version>3.6.5</cxf-codegen.version>
         <jsoup.version>1.16.1</jsoup.version>
     </properties>
 
@@ -59,6 +60,10 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.santuario</groupId>
+                    <artifactId>xmlsec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!--<dependency>
@@ -70,6 +75,11 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.80</version>
+        </dependency>-->
+        <!--<dependency>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+            <version>2.3.5</version>
         </dependency>-->
         <dependency>
             <groupId>org.apache.cxf</groupId>
@@ -110,7 +120,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-codegen-plugin</artifactId>
-            <version>3.6.5</version>
+            <version>${cxf-codegen.version}</version>
         </dependency>
          <dependency>
             <groupId>org.jsoup</groupId>
@@ -126,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>${cxf-codegen.version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>


### PR DESCRIPTION
- Fjernet duplikat av `cxf-rt-ws-security`.
- Lagt til exclusions på sårbare biblioteker under `cxf-rt-ws-security`, men la ikke inn disse som egne avhengigheter ettersom prosjektet bygde fint uten.
- Oppdatert `cxf-codegen-plugin` til nyeste `3.6.X`-versjon.

Jeg har verifisert at genererte Java-filer under `target/generated-sources` har blitt identisk som tidligere.