### PR TITLE
Setter pom version til github release version

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       version:
         description: "Version to publish (e.g. 1.2.3 or v1.2.3)"
-        required: false
+        required: true
         default: ""
   release:
     types: [published]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -2,6 +2,11 @@ name: Maven Package
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3 or v1.2.3)"
+        required: false
+        default: ""
   release:
     types: [published]
 
@@ -22,6 +27,19 @@ jobs:
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Set release version
+      run: |
+        RAW_VERSION="${{ github.event.release.tag_name || github.event.inputs.version }}"
+        VERSION="${RAW_VERSION#v}"
+        if [ -z "$VERSION" ] || ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$ ]]; then
+          echo "Error: Invalid or missing version '${VERSION}'. Expected format e.g. 1.2.3 or 1.2.3-SNAPSHOT." >&2
+          exit 1
+        fi
+        echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Set version in pom.xml
+      run: mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Version to publish (e.g. 1.2.3 or v1.2.3)"
         required: true
-        default: ""
+        default: "0.1.0-SNAPSHOT"
   release:
     types: [published]
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <artifactId>emottak-payload-xsd</artifactId>
     <name>Java representasjon av payload relaterte xsd-er brukt fra emottak</name>
-    <version>0.0.12</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <distributionManagement>


### PR DESCRIPTION
Setter maven version fra Github Release, slik at vi slipper å oppdatere pom.xml med versjon. Forventet format ved release er `v1.2.3` eller `1.2.3`.